### PR TITLE
Fix nextjs build error for static params

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -6,38 +6,9 @@ import { BlogPostContent } from '@/components/blog-post-content'
 
 // Genera i parametri statici per il build
 export async function generateStaticParams() {
-  try {
-    console.log('📦 Generating static params for blog posts...')
-    
-    // Usa la funzione getAllPosts esistente che ha migliore error handling
-    const { posts } = await getAllPosts(100) // Prendiamo i primi 100 post
-    
-    console.log(`📦 Found ${posts.length} posts for static generation`)
-    
-    if (posts.length > 0) {
-      const params = posts.map((post) => ({
-        slug: post.slug,
-      }))
-      
-      console.log('📦 Generated params:', params.map(p => p.slug).join(', '))
-      return params
-    }
-    
-    // Se non ci sono post dall'API, fallback a parametri di esempio
-    console.log('📦 No posts found from API, using fallback params')
-    return [
-      { slug: 'esempio-post' },
-    ]
-  } catch (error) {
-    console.error('❌ Error generating static params:', error)
-    
-    // Se la chiamata API fallisce durante il build, usa parametri di fallback
-    // Questo permette al build di completarsi anche se WordPress è offline
-    console.log('📦 API unreachable, using fallback params for build')
-    return [
-      { slug: 'esempio-post' },
-    ]
-  }
+  // Ritorna array vuoto per permettere generazione dinamica
+  // Le pagine saranno generate on-demand
+  return []
 }
 
 // Resto del tuo codice esistente...

--- a/lib/graphql-api.ts
+++ b/lib/graphql-api.ts
@@ -119,10 +119,28 @@ async function fetchGraphQL(query: string, variables: any = {}) {
 
     if (!response.ok) {
       console.error("❌ HTTP error! status:", response.status)
+      // Try to get the response text to see what we received
+      const text = await response.text()
+      console.error("❌ Response body:", text.substring(0, 200) + "...")
       throw new Error(`HTTP error! status: ${response.status}`)
     }
 
-    const json = await response.json()
+    const text = await response.text()
+    
+    // Check if response is HTML (error page) instead of JSON
+    if (text.trim().startsWith('<!DOCTYPE') || text.trim().startsWith('<html')) {
+      console.error("❌ Received HTML instead of JSON:", text.substring(0, 200) + "...")
+      throw new Error("GraphQL endpoint returned HTML instead of JSON - check your WordPress API URL")
+    }
+
+    let json
+    try {
+      json = JSON.parse(text)
+    } catch (parseError) {
+      console.error("❌ JSON parse error:", parseError)
+      console.error("❌ Raw response:", text.substring(0, 200) + "...")
+      throw new Error("Invalid JSON response from GraphQL endpoint")
+    }
     
     console.log("📄 Response received:", json.data ? "✅ Data found" : "❌ No data")
 

--- a/lib/graphql-api.ts
+++ b/lib/graphql-api.ts
@@ -112,7 +112,7 @@ async function fetchGraphQL(query: string, variables: any = {}) {
         query,
         variables,
       }),
-      next: { revalidate: 300 }, // Cache for 5 minutes
+      next: { revalidate: 60 }, // Cache for 1 minute
     })
 
     console.log("📡 Response status:", response.status)

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -6,7 +6,6 @@ const nextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
-  output: 'export',
   trailingSlash: true,
   images: {
     unoptimized: true,


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Remove `output: 'export'` and simplify `generateStaticParams` to fix Next.js build errors with dynamic blog pages.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `output: 'export'` configuration was causing build failures because it requires all pages to be static, conflicting with the dynamic nature of the blog posts. By removing this and simplifying `generateStaticParams` to generate pages on-demand, the build now completes successfully, even if the external GraphQL API is temporarily unavailable. Additionally, improved error handling for GraphQL responses prevents cryptic JSON parsing errors when the API returns HTML.